### PR TITLE
Safely disposing of serviceProvider

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,13 +10,11 @@ namespace DI_Configuration_Logging_ConsoleApp
     {
         static void Main(string[] args)
         {
-            ServiceProvider serviceProvider = RegisterServices(args);
+            using ServiceProvider serviceProvider = RegisterServices(args);
             IConfiguration configuration = serviceProvider.GetService<IConfiguration>();
 
             ILogger logger = serviceProvider.GetService<ILogger<Program>>();
             logger.LogInformation("Github api url is: {githubApiUrl}", configuration["github:apiUrl"]);
-
-            serviceProvider.Dispose();
         }
 
         private static ServiceProvider RegisterServices(string[] args)


### PR DESCRIPTION
The original code has a manual `serviceProvider.Dipose()` call at the end of the `Main` method. Here I've changed over to using the `using` declaration (C# 8) so that it gets safely disposed even if an exception is thrown.